### PR TITLE
Merge 'develop' to 'main' for version 0.0.5

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,72 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ develop, main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ develop ]
+  schedule:
+    - cron: '28 6 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+        
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+
+    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+
+    # - run: |
+    #   echo "Run, Build Application using script"
+    #   ./location_of_script_within_repo/buildscript.sh
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -15,6 +15,6 @@ jobs:
       with:
         dotnet-version: 6.0.x
     - name: Pack
-      run: dotnet pack --include-symbols --include-source --configuration release -p:ContinuousIntegrationBuild=true
+      run: dotnet pack --include-symbols --include-source --configuration release
     - name: Publish
       run: nuget push './**/NuSource.FluentConversions.*.nupkg' -Source 'https://api.nuget.org/v3/index.json' -ApiKey '${{ secrets.NUGET_DOT_ORG_API_KEY }}' -SkipDuplicate

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -44,5 +44,5 @@ jobs:
         shell: powershell
         run: |
           .\.sonar\scanner\dotnet-sonarscanner begin /k:"NuSource_FluentConversions" /o:"nusource" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
-          dotnet build
+          dotnet build --configuration debug
           .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,0 +1,48 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ main, develop ]
+    
+jobs:
+  sonar:
+    name: Scan
+    runs-on: windows-latest
+    steps:
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~\sonar\cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache SonarCloud scanner
+        id: cache-sonar-scanner
+        uses: actions/cache@v1
+        with:
+          path: .\.sonar\scanner
+          key: ${{ runner.os }}-sonar-scanner
+          restore-keys: ${{ runner.os }}-sonar-scanner
+      - name: Install SonarCloud scanner
+        if: steps.cache-sonar-scanner.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          New-Item -Path .\.sonar\scanner -ItemType Directory
+          dotnet tool update dotnet-sonarscanner --tool-path .\.sonar\scanner
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        shell: powershell
+        run: |
+          .\.sonar\scanner\dotnet-sonarscanner begin /k:"NuSource_FluentConversions" /o:"nusource" /d:sonar.login="${{ secrets.SONAR_TOKEN }}" /d:sonar.host.url="https://sonarcloud.io"
+          dotnet build
+          .\.sonar\scanner\dotnet-sonarscanner end /d:sonar.login="${{ secrets.SONAR_TOKEN }}"

--- a/NuSource.FluentConversions/ConversionException.cs
+++ b/NuSource.FluentConversions/ConversionException.cs
@@ -1,10 +1,16 @@
+using System.Runtime.Serialization;
+
 namespace NuSource.FluentConversions;
 
+[Serializable]
 public class ConversionException : ApplicationException
 {
-    public ConversionException(string message) 
-        : base(message)
-    {
-        
-    }
+    public ConversionException(string? message) 
+        : base(message) { }
+    
+    public ConversionException(string? message, Exception? innerException)
+        : base(message, innerException) { }
+    
+    protected ConversionException(SerializationInfo info, StreamingContext context) 
+        : base(info, context) { }
 }

--- a/NuSource.FluentConversions/NuSource.FluentConversions.csproj
+++ b/NuSource.FluentConversions/NuSource.FluentConversions.csproj
@@ -19,6 +19,10 @@
         <Description>Simple and fluent conversions for various units.</Description>
     </PropertyGroup>
 
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
+
     <ItemGroup>
         <None Include="../README.md" Pack="true" PackagePath="\" />
     </ItemGroup>

--- a/NuSource.FluentConversions/NuSource.FluentConversions.csproj
+++ b/NuSource.FluentConversions/NuSource.FluentConversions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>

--- a/NuSource.FluentConversions/NuSource.FluentConversions.csproj
+++ b/NuSource.FluentConversions/NuSource.FluentConversions.csproj
@@ -6,9 +6,9 @@
         <Nullable>enable</Nullable>
         <LangVersion>10</LangVersion>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-        <PackageVersion>0.0.4</PackageVersion>
-        <AssemblyVersion>0.0.4</AssemblyVersion>
-        <FileVersion>0.0.4</FileVersion>
+        <PackageVersion>0.0.5</PackageVersion>
+        <AssemblyVersion>0.0.5</AssemblyVersion>
+        <FileVersion>0.0.5</FileVersion>
         <Company>NuSource</Company>
         <RepositoryUrl>https://github.com/NuSource/FluentConversions</RepositoryUrl>
         <RepositoryType>git</RepositoryType>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 NuGet package link: https://www.nuget.org/packages/NuSource.FluentConversions/
 
+## About
 Simple and fluent conversions for various units.
 
 ```csharp
@@ -11,3 +12,8 @@ Console.WriteLine($"3 meters is {inc} inches."); // 3 meters is 118.1102362206 i
 double c = FluentConvert.FromTemperature(32.0, TemperatureType.Fahrenheit).To(TemperatureType.Celsius);
 Console.WriteLine($"32f is {c}c."); // 32f is 0c.
 ```
+
+Full documentation can be found on the GitHub wiki: https://github.com/NuSource/FluentConversions/wiki
+
+## Contributing
+All contributor branches should track the `develop` branch, and the `main` branch is only for releases.


### PR DESCRIPTION
Since the last release:
- Enabled CodeQL analysis
- Enabled SonarCould scanning
- Fixed ConversionException not implementing ISerializable properly
- Support for multiple .NET Standard versions
- Fixed deterministic builds not working for the NuGet publish Action